### PR TITLE
fix: don't widen toolbar icons by default; make spacing live-update

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"version": "node scripts/version-bump.mjs && git add manifest.json versions.json",
 		"icons": "node scripts/update-icon-list.mjs",
 		"build:css": "npx tailwindcss -i ./main.css -o ./styles.css --minify",
-		"build": "npm run build:esbuild && npm run build:css",
+		"build": "npm run build:esbuild",
 		"dev:css": "npx tailwindcss -i ./main.css -o ./styles.css --watch",
 		"dev": "npm-run-all --parallel dev:*",
 		"lint": "eslint .",

--- a/scripts/esbuild.config.mjs
+++ b/scripts/esbuild.config.mjs
@@ -5,6 +5,7 @@ import alias from "esbuild-plugin-alias";
 import { sassPlugin } from "esbuild-sass-plugin";
 import { createRequire } from "module";
 import { renameSync, copyFileSync, appendFileSync } from "fs";
+import { execSync } from "child_process";
 const require = createRequire(import.meta.url);
 
 const banner = `/*
@@ -70,7 +71,7 @@ const buildOptions = {
 		}),
 		sassPlugin(),
 		{
-			name: "Insert Tailwind Directives",
+			name: "Build stylesheet",
 			setup(build) {
 				build.onEnd(() => {
 					try {
@@ -80,6 +81,22 @@ const buildOptions = {
 						);
 					} catch (error) {
 						console.error(error);
+						return;
+					}
+					// Compile main.css (SCSS output + @tailwind directives) into
+					// the styles.css Obsidian loads. In watch mode the parallel
+					// `dev:css` task owns this, so only run it for production
+					// builds — that keeps `npm run build:esbuild` self-sufficient
+					// and never leaves a raw, utility-less styles.css behind.
+					if (prod) {
+						try {
+							execSync(
+								"npx tailwindcss -i ./main.css -o ./styles.css --minify",
+								{ stdio: "inherit" }
+							);
+						} catch (error) {
+							console.error("Failed to compile styles.css:", error);
+						}
 					}
 				});
 			},
@@ -88,13 +105,6 @@ const buildOptions = {
 			name: "Move output",
 			setup(build) {
 				build.onEnd(() => {
-					// Always copy main.css → styles.css locally so Obsidian loads current styles
-					try {
-						copyFileSync("main.css", "styles.css");
-					} catch (error) {
-						console.error("Failed to copy main.css → styles.css:", error);
-					}
-
 					setTimeout(
 						() => {
 							try {

--- a/src/__tests__/styles.test.ts
+++ b/src/__tests__/styles.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { updateStyles, removeStyles } from "../util";
+import { updateStyles, removeStyles, updateSpacing } from "../util";
 import type { AdvancedToolbarSettings } from "../types";
 
 const defaultSettings: AdvancedToolbarSettings = {
@@ -75,5 +75,43 @@ describe("removeStyles", () => {
 		expect(document.body.classList.contains("AT-multirow")).toBe(false);
 		expect(document.body.classList.contains("AT-row")).toBe(false);
 		expect(document.body.classList.contains("AT-column")).toBe(false);
+	});
+
+	it("clears the custom-spacing var and class", () => {
+		updateSpacing(12);
+		removeStyles();
+		expect(document.body.style.getPropertyValue("--cmdr-spacing")).toBe("");
+		expect(document.body.classList.contains("cmdr-custom-spacing")).toBe(
+			false
+		);
+	});
+});
+
+describe("updateSpacing", () => {
+	it("sets the var and gating class for a positive value", () => {
+		updateSpacing(16);
+		expect(document.body.style.getPropertyValue("--cmdr-spacing")).toBe(
+			"16px"
+		);
+		expect(document.body.classList.contains("cmdr-custom-spacing")).toBe(
+			true
+		);
+	});
+
+	it("adds nothing at 0 so native spacing is untouched", () => {
+		updateSpacing(0);
+		expect(document.body.style.getPropertyValue("--cmdr-spacing")).toBe("");
+		expect(document.body.classList.contains("cmdr-custom-spacing")).toBe(
+			false
+		);
+	});
+
+	it("clears a previously-set value when returning to 0", () => {
+		updateSpacing(16);
+		updateSpacing(0);
+		expect(document.body.style.getPropertyValue("--cmdr-spacing")).toBe("");
+		expect(document.body.classList.contains("cmdr-custom-spacing")).toBe(
+			false
+		);
 	});
 });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,7 +19,7 @@ export const DEFAULT_SETTINGS: CommanderSettings = {
 		statusbar: [],
 		leftRibbon: [],
 	},
-	spacing: 8,
+	spacing: 0,
 	advancedToolbar: {
 		rowHeight: 48,
 		rowCount: 1,

--- a/src/main.ts
+++ b/src/main.ts
@@ -167,6 +167,27 @@ export default class CommanderPlugin extends Plugin {
 				...advancedToolbar,
 			},
 		};
+
+		// One-time migration (TODO: remove in a future version). The old default
+		// `spacing: 8` applied `margin-right: 8px` to every toolbar icon,
+		// Obsidian's own included — a regression from the native baseline. Reset a
+		// persisted 8 back to 0 once; `spacingReset` guards re-runs so a
+		// deliberate re-set to 8 sticks. A fresh vault has nothing to migrate, so
+		// it records the flag in memory without writing to disk.
+		if (this.settings.spacingReset === undefined) {
+			if (this.settings.spacing === 8) this.settings.spacing = 0;
+			this.settings.spacingReset = true;
+			if (isObject(loaded)) {
+				try {
+					await this.saveSettings();
+				} catch (e) {
+					console.error(
+						"Commander: could not persist spacing migration",
+						e
+					);
+				}
+			}
+		}
 	}
 
 	public async saveSettings(): Promise<void> {

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -511,24 +511,39 @@
 }
 
 .cmdr-slider {
-	.setting-item-control > div {
+	// Match core's .setting-item-control layout: reset button sits inline to the
+	// left of the value + slider, vertically centred and right-aligned as a
+	// group. `gap` spaces all three children evenly.
+	.cmdr-slider-control {
+		display: flex;
+		align-items: center;
+		justify-content: flex-end;
+		gap: var(--size-4-2);
 		width: 100%;
 	}
-	input.slider {
-		margin-left: 4px;
+}
+
+// Extra spacing between *all* toolbar icons (core + Commander's), driven by the
+// "custom spacing" slider. The whole block is gated on `.cmdr-custom-spacing`,
+// which `updateSpacing()` only adds while the slider is above 0 — so at the
+// default of 0 Commander adds no margin anywhere and native/theme spacing is
+// untouched (toggling the plugin on/off is a no-op).
+//
+// Title-bar / status-bar / ribbon buttons previously subtracted a hard-coded 8px
+// here (`calc(var(--cmdr-spacing) - 8px)`), which made the slider a no-op at the
+// old default of 8 and pulled those icons together for any value below it. They
+// now use the same raw value as .view-action. A persisted spacing of 8 is
+// migrated to 0 (see loadSettings); other custom values apply uniformly.
+.cmdr-custom-spacing {
+	.view-action:not(:last-child),
+	.titlebar-button:not(:last-child),
+	.status-bar-item:not(:last-child) {
+		margin-right: var(--cmdr-spacing);
 	}
-}
 
-.view-action:not(:last-child) {
-	margin-right: var(--cmdr-spacing);
-}
-.titlebar-button:not(:last-child),
-.status-bar-item:not(:last-child) {
-	margin-right: calc(var(--cmdr-spacing) - 8px);
-}
-
-.side-dock-ribbon-action:not(:last-child) {
-	margin-bottom: calc(var(--cmdr-spacing) - 8px);
+	.side-dock-ribbon-action:not(:last-child) {
+		margin-bottom: var(--cmdr-spacing);
+	}
 }
 
 .cmdr-cta {

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,13 @@ export interface CommanderSettings {
 		leftRibbon: string[];
 	};
 	spacing: number;
+	/**
+	 * Set once the one-time `spacing: 8` -> `0` migration has run. The old
+	 * default of 8 silently widened *all* toolbar icons (Obsidian's included);
+	 * this flag stops the migration from re-running if a user deliberately
+	 * sets 8 again. TODO: remove this in a future version.
+	 */
+	spacingReset?: boolean;
 	advancedToolbar: AdvancedToolbarSettings;
 }
 

--- a/src/ui/components/settingComponent.tsx
+++ b/src/ui/components/settingComponent.tsx
@@ -105,7 +105,7 @@ export function SliderComponent({
 			name={props.name}
 			className="cmdr-slider"
 		>
-			<div class="cmdr-flex cmdr-items-center">
+			<div class="cmdr-slider-control">
 				{defaultValue !== undefined && (
 					<ObsidianIcon
 						aria-label={t("Restore default")}
@@ -144,7 +144,7 @@ export function SliderComponent({
 					max={props.max ?? "32"}
 					step={props.step ?? "1"}
 					value={val}
-					onPointerMove={({ target }): void => {
+					onInput={({ target }): void => {
 						const value = Number((target as HTMLInputElement).value);
 						if (!isNaN(value) && val !== value) {
 							setVal(value);

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -126,7 +126,21 @@ export async function showConfetti({ target }: MouseEvent): Promise<void> {
 }
 
 export function updateSpacing(spacing: number): void {
-	activeDocument.body.style.setProperty("--cmdr-spacing", `${spacing}px`);
+	// Target the main window's <body> (like updateStyles/removeStyles), not
+	// `activeDocument` — the slider lives in the settings window, so
+	// `activeDocument` there is the wrong document and the toolbars (which are in
+	// the main window) wouldn't update until the next reload.
+	const { style, classList } = document.body;
+	if (spacing > 0) {
+		style.setProperty("--cmdr-spacing", `${spacing}px`);
+		classList.add("cmdr-custom-spacing");
+	} else {
+		// Default (0): drop the var and the gating class entirely so the
+		// stylesheet's `margin` rules don't match at all — Commander then leaves
+		// native/theme toolbar spacing exactly as it is.
+		style.removeProperty("--cmdr-spacing");
+		classList.remove("cmdr-custom-spacing");
+	}
 }
 
 export function updateMacroCommands(plugin: CommanderPlugin): void {
@@ -170,6 +184,8 @@ export function removeStyles(): void {
 	s.removeProperty("--at-row-count");
 	s.removeProperty("--at-spacing");
 	s.removeProperty("--at-offset");
+	s.removeProperty("--cmdr-spacing");
+	c.remove("cmdr-custom-spacing");
 	c.remove("AT-multirow");
 	c.remove("AT-row");
 	c.remove("AT-column");


### PR DESCRIPTION
## Problem

`spacing` defaulted to `8`, applying `margin-right: 8px` to every `.view-action` in the tab header — Obsidian's own icons included — through an unscoped rule that was missing the `- 8px` normalisation its titlebar/status-bar/ribbon siblings had. A fresh install silently widened the native tab-header spacing; below `8` the sibling rules went **negative** and pulled the status bar / ribbon icons together. The custom-spacing slider also only took effect after a reload.

## Changes

- **Default `spacing` → 0.** All four toolbar-spacing rules are gated on a `cmdr-custom-spacing` body class that `updateSpacing()` only adds while the value is above 0, so a fresh install — and toggling the plugin on/off — is a true no-op. No `calc(... - 8px)`, no negative margins.
- **Live update.** `updateSpacing()` now writes to the main window's `document.body` (matching `updateStyles`/`removeStyles`) instead of `activeDocument`, so dragging the slider in the settings window updates the toolbars immediately. `removeStyles()` clears the var + class on unload.
- **All input methods.** `SliderComponent` listens on `input` instead of `pointermove`, so keyboard and track-click also update live and persist (was drag-only).
- **One-time migration** (in `loadSettings`) resets a saved `spacing: 8` back to `0`, guarded by a `spacingReset` flag so a deliberate re-set to 8 sticks. The write is `try/catch`ed so a failed save can't abort plugin load; a fresh vault records the flag in memory without writing to disk.
- **Slider reset button** sits inline to the left of the value + slider again — replaced the Tailwind utility classes on the wrapper with an explicit `.cmdr-slider-control` rule mirroring core's `.setting-item-control`.
- **Build:** the production esbuild run compiles `styles.css` itself via the Tailwind CLI in its `onEnd` hook, instead of copying the raw `main.css` over it (which stripped every utility class from the stylesheet Obsidian loads). `npm run build` is now just `build:esbuild`; `dev` still uses the `dev:css` watch.

## Behaviour change to note in the changelog

For users who set a **custom** spacing value other than 8, the status bar / ribbon / title bar now use that raw value instead of `value - 8px`, so those groups are up to 8px wider than before (and consistent with the tab bar). A saved `8` migrates to `0`.

## Testing

- `npm test` — 72 pass (added `updateSpacing` coverage)
- `npm run build` + lint clean
- Manually verified in Obsidian 1.13.7: fresh/default = no spacing change vs plugin disabled; slider drags/keyboard update tab bar, status bar and ribbon live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)