### PR TITLE
Make feedback/donate text links in the About badge

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -59,6 +59,7 @@
 	"Done": "Done",
 	"By Johnny✨ and phibr0": "By Johnny✨ and phibr0",
 	"Leave feedback": "Leave feedback",
+	"Send feedback": "Send feedback",
 	"Donate": "Donate",
 	"Share feedback, issues, and ideas with our feedback form.": "Share feedback, issues, and ideas with our feedback form.",
 	"Consider donating to support development.": "Consider donating to support development.",

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -422,23 +422,22 @@
 		margin-top: 0;
 	}
 
-	button {
+	.cmdr-about-links {
 		display: flex;
+		flex-direction: column;
 		align-items: center;
-		height: 2.6em;
-		font-weight: 700;
-		gap: 16px;
-		border-radius: 6px;
-		margin-bottom: 8px;
+		gap: 0;
+		font-size: 13px;
 
-		&:last-of-type {
-			margin-bottom: 32px;
-		}
-	}
+		a {
+			color: var(--text-muted);
+			text-decoration: none;
+			cursor: pointer;
 
-	.setting-item {
-		button {
-			margin: 0;
+			&:hover {
+				color: var(--text-accent);
+				text-decoration: underline;
+			}
 		}
 	}
 

--- a/src/ui/components/About.tsx
+++ b/src/ui/components/About.tsx
@@ -1,7 +1,7 @@
-import { Platform, PluginManifest } from "obsidian";
+import { PluginManifest } from "obsidian";
 import { h } from "preact";
 import t from "src/l10n";
-import { showConfetti, ObsidianIcon } from "src/util";
+import { showConfetti } from "src/util";
 import Credits from "./Credits";
 import Logo from "./Logo";
 
@@ -10,79 +10,40 @@ export default function About({
 }: {
 	manifest: PluginManifest;
 }): h.JSX.Element {
-	const feedbackBtn = (
-		<button
-			className="mod-cta"
-			onClick={(e): void => {
-				void showConfetti(e);
-				window.setTimeout(
-					() =>
-						location.replace("https://forms.gle/hPjn61G9bqqFb3256"),
-					Math.random() * 800 + 500
-				);
-			}}
-		>
-			<ObsidianIcon icon="message-square" size={20} />
-			{t("Leave feedback")}
-		</button>
-	);
-	const donateBtn = (
-		<button
-			className="mod-cta"
-			onClick={(e): void => {
-				void showConfetti(e);
-				window.setTimeout(
-					() => location.replace("https://buymeacoffee.com/johnny1093"),
-					Math.random() * 800 + 500
-				);
-			}}
-		>
-			<ObsidianIcon icon="coffee" size={20} />
-			{t("Support development")}
-		</button>
-	);
+	const openWithConfetti =
+		(url: string) =>
+		(e: h.JSX.TargetedMouseEvent<HTMLAnchorElement>): void => {
+			e.preventDefault();
+			void showConfetti(e);
+			window.setTimeout(
+				() => location.replace(url),
+				Math.random() * 800 + 500
+			);
+		};
+
 	return (
 		<div className="cmdr-about">
-			{Platform.isMobile && [<hr />, feedbackBtn, donateBtn]}
-			{Platform.isDesktop && [
-				<div
-					className="setting-item mod-toggle"
-					style={{
-						width: "100%",
-						borderTop:
-							"1px solid var(--background-modifier-border)",
-						paddingTop: "18px",
-					}}
-				>
-					<div className="setting-item-info">
-						<div className="setting-item-name">
-							{t("Leave feedback")}
-						</div>
-						<div className="setting-item-description">
-							{t(
-								"Share feedback, issues, and ideas with our feedback form."
-							)}
-						</div>
-					</div>
-					<div className="setting-item-control">{feedbackBtn}</div>
-				</div>,
-				<div
-					className="setting-item mod-toggle"
-					style={{ width: "100%" }}
-				>
-					<div className="setting-item-info">
-						<div className="setting-item-name">{t("Donate")}</div>
-						<div className="setting-item-description">
-							{t("Consider donating to support development.")}
-						</div>
-					</div>
-					<div className="setting-item-control">{donateBtn}</div>
-				</div>,
-				<hr />,
-			]}
 			<Logo />
 			<b>{manifest.name}</b>
 			<Credits />
+			<div className="cmdr-about-links">
+				<a
+					href="https://forms.gle/hPjn61G9bqqFb3256"
+					onClick={openWithConfetti(
+						"https://forms.gle/hPjn61G9bqqFb3256"
+					)}
+				>
+					{t("Send feedback")}
+				</a>
+				<a
+					href="https://buymeacoffee.com/johnny1093"
+					onClick={openWithConfetti(
+						"https://buymeacoffee.com/johnny1093"
+					)}
+				>
+					{t("Donate")}
+				</a>
+			</div>
 			<a
 				className="cmdr-version"
 				href={


### PR DESCRIPTION
## What

Replaces the two full-width **Leave feedback** / **Donate** setting rows in the About tab (and their mobile CTA buttons) with two muted text links stacked in the About badge, between the "By Johnny✨ and phibr0" credits line and the version number.

- Relabelled to **Send feedback** and **Donate**
- Links flow at the same line rhythm as the surrounding badge text (no extra margins)
- Confetti burst + delayed redirect behaviour preserved; links now also carry a real `href`
- Removed the now-unused desktop/mobile `Platform` split and `ObsidianIcon` import
- Added the `Send feedback` key to `locale/en.json`

## Screenshot

Badge order: logo → Commander → By Johnny✨ and phibr0 → Send feedback → Donate → version

🤖 Generated with [Claude Code](https://claude.com/claude-code)