### PR TITLE
fix: stop persisting seen menu items to data.json (#211)

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,8 +20,6 @@ export const DEFAULT_SETTINGS: CommanderSettings = {
 		leftRibbon: [],
 		editorMenuItems: [],
 		fileMenuItems: [],
-		seenEditorMenuItems: [],
-		seenFileMenuItems: [],
 	},
 	spacing: 0,
 	advancedToolbar: {

--- a/src/main.ts
+++ b/src/main.ts
@@ -86,8 +86,16 @@ export default class CommanderPlugin extends Plugin {
 		this.settings.hide.leftRibbon ??= []; // TODO: remove this in a future version
 		this.settings.hide.editorMenuItems ??= []; // TODO: remove this in a future version
 		this.settings.hide.fileMenuItems ??= []; // TODO: remove this in a future version
-		this.settings.hide.seenEditorMenuItems ??= []; // TODO: remove this in a future version
-		this.settings.hide.seenFileMenuItems ??= []; // TODO: remove this in a future version
+
+		// #209 briefly persisted every menu-item title ever seen (to build the
+		// settings checklist). Many titles are file-specific, so this rewrote
+		// data.json on nearly every right-click and churned version-controlled
+		// configs / sync history (#211). The checklist is session-only now;
+		// strip the stale keys from existing configs.
+		// TODO: remove this in a future version.
+		const legacyHide = this.settings.hide as Record<string, unknown>;
+		delete legacyHide.seenEditorMenuItems;
+		delete legacyHide.seenFileMenuItems;
 
 		registerCustomIcons();
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -91,11 +91,25 @@ export default class CommanderPlugin extends Plugin {
 		// settings checklist). Many titles are file-specific, so this rewrote
 		// data.json on nearly every right-click and churned version-controlled
 		// configs / sync history (#211). The checklist is session-only now;
-		// strip the stale keys from existing configs.
-		// TODO: remove this in a future version.
+		// strip the stale keys from existing configs and persist the removal
+		// once so the shrink lands at upgrade rather than on the next unrelated
+		// settings change. TODO: remove this in a future version.
 		const legacyHide = this.settings.hide as Record<string, unknown>;
-		delete legacyHide.seenEditorMenuItems;
-		delete legacyHide.seenFileMenuItems;
+		if (
+			"seenEditorMenuItems" in legacyHide ||
+			"seenFileMenuItems" in legacyHide
+		) {
+			delete legacyHide.seenEditorMenuItems;
+			delete legacyHide.seenFileMenuItems;
+			try {
+				await this.saveSettings();
+			} catch (e) {
+				console.error(
+					"Commander: could not persist #211 settings cleanup",
+					e
+				);
+			}
+		}
 
 		registerCustomIcons();
 

--- a/src/manager/menuHiderManager.ts
+++ b/src/manager/menuHiderManager.ts
@@ -30,6 +30,13 @@ export interface Matcher {
 
 const SLASH_WRAPPED = /^\/(.*)\/([dgimsuy]*)$/;
 
+/**
+ * Cap on titles retained per menu scope for the settings checklist. The cache
+ * is session-only, but a long session browsing many files can still surface
+ * thousands of distinct (often file-specific) titles, so bound it.
+ */
+const SEEN_CAP = 250;
+
 /** True when `entry` is written as a `/…/flags` regex literal. */
 export function isSlashWrapped(entry: string): boolean {
 	return SLASH_WRAPPED.test(entry.trim());
@@ -190,7 +197,12 @@ export default class MenuHiderManager {
 				added = true;
 			}
 		}
-		if (added) this.emitChange();
+		if (!added) return;
+		// Sets iterate in insertion order, so this evicts oldest-seen first.
+		while (set.size > SEEN_CAP) {
+			set.delete(set.values().next().value as string);
+		}
+		this.emitChange();
 	}
 
 	/** Walk up the submenu chain to the nearest tagged ancestor. */

--- a/src/manager/menuHiderManager.ts
+++ b/src/manager/menuHiderManager.ts
@@ -13,7 +13,11 @@ import CommanderPlugin from "src/main";
  * the menu is shown, so it works with native menus on or off.
  *
  * The settings checklist is populated by recording the item titles of every
- * real menu that opens (`hide.seen*MenuItems`).
+ * real menu that opens. That record is kept in memory for the current session
+ * only — it is deliberately not persisted, because many menu titles are
+ * file-specific (e.g. "Focus '<file>' in Map View") and writing them to
+ * `data.json` on nearly every right-click churned version-controlled configs
+ * and sync history (issue #211).
  */
 
 export type MenuScope = "editorMenuItems" | "fileMenuItems";
@@ -25,9 +29,6 @@ export interface Matcher {
 }
 
 const SLASH_WRAPPED = /^\/(.*)\/([dgimsuy]*)$/;
-
-/** Most titles seen in one menu scope that we keep persisted. */
-const SEEN_CAP = 250;
 
 /** True when `entry` is written as a `/…/flags` regex literal. */
 export function isSlashWrapped(entry: string): boolean {
@@ -105,25 +106,27 @@ function isMenuItem(x: unknown): x is MenuItem {
 	return !!x && typeof (x as MenuItem).setTitle === "function";
 }
 
-const SEEN_KEY: Record<MenuScope, "seenEditorMenuItems" | "seenFileMenuItems"> = {
-	editorMenuItems: "seenEditorMenuItems",
-	fileMenuItems: "seenFileMenuItems",
-};
-
 export default class MenuHiderManager {
 	private readonly plugin: CommanderPlugin;
 	private matchers: Record<MenuScope, Matcher[]> = {
 		editorMenuItems: [],
 		fileMenuItems: [],
 	};
+	/**
+	 * Titles seen in real menus this session, per scope. Session-only by
+	 * design — see the file header. Feeds the settings checklist alongside the
+	 * user's own persisted entries.
+	 */
+	private readonly seen: Record<MenuScope, Set<string>> = {
+		editorMenuItems: new Set(),
+		fileMenuItems: new Set(),
+	};
 	private readonly changeListeners = new Set<() => void>();
-	private saveTimer: number | null = null;
 
 	public constructor(plugin: CommanderPlugin) {
 		this.plugin = plugin;
 		this.recompile();
 		this.patch();
-		this.plugin.register(() => this.flushSave());
 	}
 
 	/** Rebuild the compiled matcher lists. Call after settings change. */
@@ -144,11 +147,9 @@ export default class MenuHiderManager {
 		(menu as TaggedMenu).__cmdrMenuScope = scope;
 	}
 
-	/** Persisted list of titles ever seen in this menu scope, sorted. */
+	/** Titles seen in this menu scope this session, sorted. */
 	public getSeen(scope: MenuScope): string[] {
-		return [...this.plugin.settings.hide[SEEN_KEY[scope]]].sort((a, b) =>
-			a.localeCompare(b)
-		);
+		return [...this.seen[scope]].sort((a, b) => a.localeCompare(b));
 	}
 
 	/** Subscribe to seen-list changes; returns an unsubscribe function. */
@@ -181,33 +182,15 @@ export default class MenuHiderManager {
 
 	private recordSeen(scope: MenuScope, titles: string[]): void {
 		if (titles.length === 0) return;
-		const list = this.plugin.settings.hide[SEEN_KEY[scope]];
+		const set = this.seen[scope];
 		let added = false;
 		for (const title of titles) {
-			if (!list.includes(title)) {
-				list.push(title);
+			if (!set.has(title)) {
+				set.add(title);
 				added = true;
 			}
 		}
-		if (!added) return;
-		if (list.length > SEEN_CAP) list.splice(0, list.length - SEEN_CAP);
-		this.scheduleSave();
-		this.emitChange();
-	}
-
-	private scheduleSave(): void {
-		if (this.saveTimer !== null) window.clearTimeout(this.saveTimer);
-		this.saveTimer = window.setTimeout(() => {
-			this.saveTimer = null;
-			void this.plugin.saveSettings();
-		}, 800);
-	}
-
-	private flushSave(): void {
-		if (this.saveTimer === null) return;
-		window.clearTimeout(this.saveTimer);
-		this.saveTimer = null;
-		void this.plugin.saveSettings();
+		if (added) this.emitChange();
 	}
 
 	/** Walk up the submenu chain to the nearest tagged ancestor. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,10 +42,6 @@ export interface CommanderSettings {
 		editorMenuItems: string[];
 		/** Titles/regexes removed from the file right-click menu. */
 		fileMenuItems: string[];
-		/** Menu-item titles observed in editor menus, for the settings checklist. */
-		seenEditorMenuItems: string[];
-		/** Menu-item titles observed in file menus, for the settings checklist. */
-		seenFileMenuItems: string[];
 	};
 	spacing: number;
 	/**


### PR DESCRIPTION
Fixes #211.

## Problem

The menu-item hider added in #209 persists every menu-item title it has ever seen into `data.json` (`hide.seenEditorMenuItems` / `hide.seenFileMenuItems`) to populate the settings checklist. Many menu titles are file-specific (`Focus '<file>' in Map View`, `Close tabs after`, …), so the list grows on nearly every right-click, `data.json` is rewritten 800 ms later, and the churn pollutes version-controlled configs and multi-device sync history. `SEEN_CAP = 250` bounds the size but not the churn.

## Change

- **Session-only checklist.** Seen titles now live in an in-memory `Set` per scope on `MenuHiderManager` instead of `settings.hide.seen*`. Nothing is written to `data.json`. The checklist still fills in as menus are opened (the UI already tells users to open a menu once), and entries the user has actually chosen to hide stay persisted in `hide.editorMenuItems` / `hide.fileMenuItems` and are always shown.
- **One-time cleanup.** On load, the stale `seen*` keys are deleted from existing configs and — when present — `saveSettings()` is called once so the shrink lands at upgrade rather than on the next unrelated settings change.
- The session cache keeps the `SEEN_CAP` (250) bound, evicting oldest-seen entries first, so a long session browsing many files doesn't accumulate unbounded strings in memory.
- Removed the now-dead `scheduleSave` / `flushSave` / `saveTimer` debounced-write path and dropped the fields from `types.ts` / `constants.ts`.

## Behavior change

Right after launch the checklist only lists candidates for menus opened this session — you open a menu once and its items appear (as the existing hint text describes). Hiding itself is unchanged.

## Testing

- `tsc -noEmit` clean
- `vitest run` — 87/87 pass
- `eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)